### PR TITLE
prefix PATH with 'node_modules/.bin', like 'npm run' does

### DIFF
--- a/src/run.ls
+++ b/src/run.ls
@@ -167,7 +167,8 @@ exec = (emitter, command, cwd, hook) -> (done) ->
   (cmd-str = "#{cmd} #{args.join ' '}") |> emitter.emit 'command', _, hook
   cmd-str |> emitter.emit 'start', _ if hook is 'start'
 
-  process.env.PATH = "node_modules/.bin#{delimiter}#{process.env.PATH}"
+  if process.env.PATH.indexOf("node_modules/.bin") isnt 0
+    process.env.PATH = "node_modules/.bin#{delimiter}#{process.env.PATH}"
 
   child = cmd |> spawn _, args, { cwd, process.env }
   child.stdout.on 'data', -> it.to-string! |> emitter.emit 'stdout', _

--- a/src/run.ls
+++ b/src/run.ls
@@ -167,6 +167,8 @@ exec = (emitter, command, cwd, hook) -> (done) ->
   (cmd-str = "#{cmd} #{args.join ' '}") |> emitter.emit 'command', _, hook
   cmd-str |> emitter.emit 'start', _ if hook is 'start'
 
+  process.env.PATH = "node_modules/.bin#{delimiter}#{process.env.PATH}"
+
   child = cmd |> spawn _, args, { cwd, process.env }
   child.stdout.on 'data', -> it.to-string! |> emitter.emit 'stdout', _
   child.stderr.on 'data', -> it.to-string! |> emitter.emit 'stderr', _


### PR DESCRIPTION
When creating executables, nar does not currently set the PATH correctly. Or rather, it doesn't behave like 'npm run', which prepends 'node_modules/.bin' to PATH in order to run the project-local binaries over the globally installed ones. This matters a lot when running coffee-script, for example.

